### PR TITLE
fixes #9746 - load version code to fix `hammer --version`

### DIFF
--- a/lib/hammer_cli_foreman_discovery.rb
+++ b/lib/hammer_cli_foreman_discovery.rb
@@ -1,3 +1,4 @@
 module HammerCLIForemanDiscovery
   require 'hammer_cli_foreman_discovery/discovery'
+  require 'hammer_cli_foreman_discovery/version'
 end


### PR DESCRIPTION
Test failure was fixed in hammer-cli's master branch by pinning highline, but I expect the test will use the latest released version.