### PR TITLE
Fixes #11803 : Update gettext to 3.X to be consistent with hammer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Gemfile.local
 .idea
 *gem
 coverage
+
+# Locale files
+locale/*/*.edit.po
+locale/*/*.po.time_stamp

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [foreman.hammer_cli_foreman_discovery]
-file_filter = locale/<lang>/hammer_cli_foreman_discovery.po
+file_filter = locale/<lang>/hammer_cli_foreman_discovery.edit.po
 source_file = locale/hammer_cli_foreman_discovery.pot
 source_lang = en
 type = PO

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'gettext', '~> 2.0'
+gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 group :test do
   gem 'rake', '~> 10.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -10,14 +10,27 @@ end
 
 namespace :gettext do
   desc "Update pot file"
-  task :find do
+  task :setup do
     require "hammer_cli_foreman_discovery/version"
     require "hammer_cli_foreman_discovery/i18n"
-    require 'gettext/tools'
+    require 'gettext/tools/task'
 
     domain = HammerCLIForemanDiscovery::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name, domain.translated_files, "#{domain.domain_name} #{HammerCLIForemanDiscovery.version.to_s}", :po_root => domain.locale_dir)
+    GetText::Tools::Task.define do |task|
+      task.package_name = domain.domain_name
+      task.package_version = HammerCLIForemanDiscovery.version.to_s
+      task.domain = domain.domain_name
+      task.mo_base_directory = domain.locale_dir
+      task.po_base_directory = domain.locale_dir
+      task.files = domain.translated_files
+    end
   end
+
+  desc "Update pot file"
+  task :find => [:setup] do
+    Rake::Task["gettext:po:update"].invoke
+  end
+
 end
 
 namespace :pkg do


### PR DESCRIPTION
This includes chanegs to the gems, rakefile, and the transifex
configuration to take into consideration the edit and timestamp files