### PR TITLE
Display model_name with list command

### DIFF
--- a/lib/hammer_cli_foreman_discovery/discovery.rb
+++ b/lib/hammer_cli_foreman_discovery/discovery.rb
@@ -15,6 +15,7 @@ module HammerCLIForemanDiscovery
         field :id, _("ID")
         field :name, _("Name")
         field :mac, _("MAC")
+        field :model_name, _("Model")
         field :last_report, _('Last report'), Fields::Date
         field :cpus, _('CPUs')
         field :memory, _('Memory')


### PR DESCRIPTION
Running 
`hammer -d discovery list`
shows that API sends model_name in response but this field never gets displayed.
So I had to patch hammer_cli_foreman_discovery/discovery.rb to display it.
Is it intentionally omitted?