### PR TITLE
Fixes #19751 - facts command fixed

### DIFF
--- a/lib/hammer_cli_foreman_discovery/discovery.rb
+++ b/lib/hammer_cli_foreman_discovery/discovery.rb
@@ -53,6 +53,12 @@ module HammerCLIForemanDiscovery
         HammerCLIForeman::Fact::ListCommand.unhash_facts(super)
       end
 
+      def request_params
+        params = super
+        params['host_id'] = params.delete('discovered_host_id')
+        params
+      end
+
       build_options
     end
 


### PR DESCRIPTION
Command hammer discovery facts --name mac525400549b27 does not work returning Field 'discovered_host' not recognized for searching!

Quick merge @dLobato @orrabin @orabin @tstrachota for the 1.0.0 release for 1.15 please?