### PR TITLE
Remove puppet

### DIFF
--- a/lib/hammer_cli_foreman_discovery/discovery.rb
+++ b/lib/hammer_cli_foreman_discovery/discovery.rb
@@ -79,8 +79,6 @@ module HammerCLIForemanDiscovery
         option "--root-password", "ROOT_PW", " "
         option "--ask-root-password", "ASK_ROOT_PW", " ",
                     :format => HammerCLI::Options::Normalizers::Bool.new
-        option "--puppetclass-ids", "PUPPETCLASS_IDS", " ",
-                    :format => HammerCLI::Options::Normalizers::List.new
 
         bool_format           = {}
         bool_format[:format] = HammerCLI::Options::Normalizers::Bool.new
@@ -99,7 +97,7 @@ module HammerCLIForemanDiscovery
         option "--provision-method", "METHOD", " ",
                     :format => HammerCLI::Options::Normalizers::Enum.new(['build', 'image'])
 
-        super :without => [:root_pass, :ptable_id, :puppet_class_ids, :host_parameters_attributes]
+        super :without => [:root_pass, :ptable_id, :host_parameters_attributes]
       end
 
       def ask_password
@@ -134,8 +132,6 @@ module HammerCLIForemanDiscovery
       end
 
       build_options
-
-      extend_with(HammerCLIForeman::CommandExtensions::PuppetEnvironment.new)
     end
 
     class AutoProvisionCommand < HammerCLIForeman::SingleResourceCommand

--- a/test/unit/discovery_test.rb
+++ b/test/unit/discovery_test.rb
@@ -66,15 +66,15 @@ describe HammerCLIForemanDiscovery::DiscoveredHost do
     let(:cmd) { HammerCLIForemanDiscovery::DiscoveredHost::ProvisionCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name, puppet_environment_id, architecture_id, domain_id, puppet_proxy_id, operatingsystem_id and more",
-                       ["--name=host", "--puppet-environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
+      it_should_accept "name, architecture_id, domain_id, operatingsystem_id and more",
+                       ["--name=host", "--architecture-id=1", "--domain-id=1", "--operatingsystem-id=1",
                         "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",
-                        "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1", '--puppet-ca-proxy-id=1', '--puppetclass-ids',
+                        "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1",
                         "--root-password=pwd", "--ask-root-password=false", "--provision-method=build"]
 
-      with_params ["--name=host", "--puppet-environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
+      with_params ["--name=host", "--architecture-id=1", "--domain-id=1", "--operatingsystem-id=1",
                    "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",
-                   "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1", '--puppet-ca-proxy-id=1', '--puppetclass-ids',
+                   "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1",
                    "--root-password=pwd", "--ask-root-password=false", "--provision-method=build", "--managed=true", "--build=true", "--enabled=true"] do
         it_should_call_action_and_test_params(:update) { |par| par["discovered_host"]["managed"] == true }
         it_should_call_action_and_test_params(:update) { |par| par["discovered_host"]["build"] == true }


### PR DESCRIPTION
puppet functionality is removed from core and hammer-cli-foreman. 
I created https://github.com/theforeman/hammer-cli-foreman-puppet/pull/20 for moving puppet functionality to hammer-cli-foreman-puppet