### PR TITLE
Fixes #34352 - Properly support Puppet plugins

### DIFF
--- a/lib/hammer_cli_foreman_discovery/command_extensions/provision_with_puppet.rb
+++ b/lib/hammer_cli_foreman_discovery/command_extensions/provision_with_puppet.rb
@@ -1,0 +1,75 @@
+module HammerCLIForemanDiscovery
+  module CommandExtensions
+    class ProvisionWithPuppet < HammerCLI::CommandExtensions
+      option_family(
+        format: HammerCLI::Options::Normalizers::List.new,
+        aliased_resource: 'puppet-class',
+        description: 'Names/Ids of associated Puppet classes'
+      ) do
+        parent '--puppet-class-ids', 'PUPPET_CLASS_IDS', _('List of Puppet class ids'),
+               attribute_name: :option_puppetclass_ids
+        child '--puppet-classes', 'PUPPET_CLASS_NAMES', '',
+              attribute_name: :option_puppetclass_names
+      end
+
+      # TODO: Until the API is cleaned up
+      option_family(
+        aliased_resource: 'environment',
+        description: _('Puppet environment. Required if host is managed and value is not inherited from host group'),
+        deprecation: _("Use %s instead") % '--puppet-environment[-id]',
+        deprecated: { '--environment' => _("Use %s instead") % '--puppet-environment[-id]',
+                      '--environment-id' => _("Use %s instead") % '--puppet-environment[-id]'}
+      ) do
+        parent '--environment-id', 'ENVIRONMENT_ID', _(''),
+               format: HammerCLI::Options::Normalizers::Number.new,
+               attribute_name: :option_environment_id
+        child '--environment', 'ENVIRONMENT_NAME', _('Environment name'),
+              attribute_name: :option_environment_name
+      end
+
+      option_family(
+        aliased_resource: 'puppet_proxy'
+      ) do
+        parent '--puppet-proxy-id', 'PUPPET_PROXY_ID', _(''),
+               format: HammerCLI::Options::Normalizers::Number.new,
+               attribute_name: :option_puppet_proxy_id
+
+      end
+      option_family(
+        aliased_resource: 'puppet_ca_proxy'
+      ) do
+        parent '--puppet-ca-proxy-id', 'PUPPET_CA_PROXY_ID', _(''),
+               format: HammerCLI::Options::Normalizers::Number.new,
+               attribute_name: :option_puppet_ca_proxy_id
+
+      end
+
+      request_params do |params, command_object|
+        if command_object.option_puppet_proxy
+          params['discovered_host']['puppet_proxy_id'] ||= HammerCLIForemanPuppet::CommandExtensions::HostPuppetProxy.proxy_id(
+            command_object.resolver, command_object.option_puppet_proxy
+          )
+        end
+        if command_object.option_puppet_ca_proxy
+          params['discovered_host']['puppet_ca_proxy_id'] ||= HammerCLIForemanPuppet::CommandExtensions::HostPuppetProxy.proxy_id(
+            command_object.resolver, command_object.option_puppet_ca_proxy
+          )
+        end
+        if command_object.option_puppetclass_ids
+          params['discovered_host']['puppet_attributes'] ||= {}
+          params['discovered_host']['puppet_attributes']['puppetclass_ids'] ||= command_object.option_puppetclass_ids
+        end
+        if command_object.option_puppetclass_names
+          params['discovered_host']['puppet_attributes'] ||= {}
+          params['discovered_host']['puppet_attributes']['puppetclass_ids'] ||= command_object.resolver.puppetclass_ids(
+            'option_names' => command_object.option_puppetclass_names
+          )
+        end
+        if params['discovered_host']['environment_id']
+          params['discovered_host']['puppet_attributes'] ||= {}
+          params['discovered_host']['puppet_attributes']['environment_id'] = params['discovered_host'].delete('environment_id')
+        end
+      end
+    end
+  end
+end

--- a/test/unit/discovery_test.rb
+++ b/test/unit/discovery_test.rb
@@ -66,15 +66,15 @@ describe HammerCLIForemanDiscovery::DiscoveredHost do
     let(:cmd) { HammerCLIForemanDiscovery::DiscoveredHost::ProvisionCommand.new("", ctx) }
 
     context "parameters" do
-      it_should_accept "name, puppet_environment_id, architecture_id, domain_id, puppet_proxy_id, operatingsystem_id and more",
-                       ["--name=host", "--puppet-environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
+      it_should_accept "name, architecture_id, domain_id, operatingsystem_id and more",
+                       ["--name=host", "--architecture-id=1", "--domain-id=1", "--operatingsystem-id=1",
                         "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",
-                        "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1", '--puppet-ca-proxy-id=1', '--puppetclass-ids',
+                        "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1",
                         "--root-password=pwd", "--ask-root-password=false", "--provision-method=build"]
 
-      with_params ["--name=host", "--puppet-environment-id=1", "--architecture-id=1", "--domain-id=1", "--puppet-proxy-id=1", "--operatingsystem-id=1",
+      with_params ["--name=host", "--architecture-id=1", "--domain-id=1", "--operatingsystem-id=1",
                    "--ip=1.2.3.4", "--mac=11:22:33:44:55:66", "--medium-id=1", "--partition-table-id=1", "--subnet-id=1",
-                   "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1", '--puppet-ca-proxy-id=1', '--puppetclass-ids',
+                   "--sp-subnet-id=1", "--model-id=1", "--hostgroup-id=1", "--owner-id=1",
                    "--root-password=pwd", "--ask-root-password=false", "--provision-method=build", "--managed=true", "--build=true", "--enabled=true"] do
         it_should_call_action_and_test_params(:update) { |par| par["discovered_host"]["managed"] == true }
         it_should_call_action_and_test_params(:update) { |par| par["discovered_host"]["build"] == true }


### PR DESCRIPTION
Requires https://github.com/theforeman/hammer-cli-foreman-puppet/pull/42.

In this PR I'm trying to support Puppet-less state as per API docs (although not sure about this one, since both discovery plugins are still outdated) and also trying to make this plugin work with Puppet plugins being installed.

Reviewers, please test both scenarios if you can.

cc @nadjaheitmann, @ezr-ondrej, @lzap