### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_discovery.gemspec
+++ b/hammer_cli_foreman_discovery.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = Dir['LICENSE', 'README*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'hammer_cli_foreman', '~> 5.0'
+  s.add_dependency 'hammer_cli_foreman', '>= 3.10', '< 6.0'
 
   s.required_ruby_version = '>= 2.7', '< 4'
 end

--- a/hammer_cli_foreman_discovery.gemspec
+++ b/hammer_cli_foreman_discovery.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = Dir['LICENSE', 'README*']
   s.require_paths = ["lib"]
 
-  s.add_dependency 'hammer_cli_foreman', '~> 3.10'
+  s.add_dependency 'hammer_cli_foreman', '~> 5.0'
 
   s.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint from ~> 3.10 to ~> 5.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)